### PR TITLE
Only cache valid response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-### Fixed
-
-- Fix a bug where bad responses would be cached
-
 ## [1.0.0](https://github.com/rokucommunity/roku-requests/compare/v0.2.0...v1.0.0) - 2022-01-12
 ### Changed
  - This project has been in the wild for years even before ropm. Releasing as v1 now that it's clear the ropm-published package is stable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `parseJson` and `parseJsonFlags` arguments
 
+### Fixed
+
+- Fix a bug where bad responses would be cached
+
 ## [1.0.0](https://github.com/rokucommunity/roku-requests/compare/v0.2.0...v1.0.0) - 2022-01-12
 
 ### Changed

--- a/src/source/Requests.brs
+++ b/src/source/Requests.brs
@@ -125,7 +125,7 @@ function Requests_request(method, url as String, args as Object)
 
     if response = invalid
         response = Requests_run(method, url, headers, data, _timeout, _retryCount, _verify)
-        if rc <> invalid and _useCache
+        if rc <> invalid and _useCache and response.ok = true
             rc.put(response)
         end if
     end if


### PR DESCRIPTION
I've hit a case where bad responses were being cached, and then I'm stuck on the bad cache over and over.
Should cache only when we have a valid response