### PR TITLE
Fix build badge and readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # roku-requests
 Simple, python requests inspired Brightscript requests framework for Roku apps
 
-[![build status](https://img.shields.io/github/workflow/status/rokucommunity/roku-requests/build.svg?logo=github)](https://github.com/rokucommunity/roku-requests/actions?query=workflow%3Abuild)
+[![build status](https://img.shields.io/github/actions/workflow/status/rokucommunity/roku-requests/build.yml?logo=github&branch=master)](https://github.com/rokucommunity/roku-requests/actions/workflows/build.yml)
 [![monthly downloads](https://img.shields.io/npm/dm/roku-requests.svg?sanitize=true&logo=npm&logoColor=)](https://npmcharts.com/compare/roku-requests?minimal=true)
 [![npm version](https://img.shields.io/npm/v/roku-requests.svg?logo=npm)](https://www.npmjs.com/package/roku-requests)
 [![license](https://img.shields.io/github/license/rokucommunity/roku-requests.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # roku-requests
+
 Simple, python requests inspired Brightscript requests framework for Roku apps
 
 [![build status](https://img.shields.io/github/actions/workflow/status/rokucommunity/roku-requests/build.yml?logo=github&branch=master)](https://github.com/rokucommunity/roku-requests/actions/workflows/build.yml)
@@ -8,11 +9,15 @@ Simple, python requests inspired Brightscript requests framework for Roku apps
 [![Slack](https://img.shields.io/badge/Slack-RokuCommunity-4A154B?logo=slack)](https://join.slack.com/t/rokudevelopers/shared_invite/zt-4vw7rg6v-NH46oY7hTktpRIBM_zGvwA)
 
 ## Installation
+
 ### Using ropm
+
 ```bash
 ropm install roku-requests
 ```
+
 ### Manually
+
 Copy `src/source/Requests.brs` into your project as `source/Requests.brs` folder
 
 ## Usage
@@ -20,6 +25,7 @@ Copy `src/source/Requests.brs` into your project as `source/Requests.brs` folder
 ### Make a Request
 
 Making a request with Requests is very simple.
+
 ```
 Brightscript Debugger> r = Requests().get("https://api.github.com/events")
 ```
@@ -75,6 +81,7 @@ Brightscript Debugger> [{"id":"8575373301","type":"WatchEvent","actor":{"id":453
 ### JSON Response Content
 
 There’s also a builtin JSON encoder/decoder, in case you’re dealing with JSON data:
+
 ```
 Brightscript Debugger> r = Requests().get("https://api.github.com/events")
 Brightscript Debugger> ?r.json
@@ -87,15 +94,19 @@ Brightscript Debugger> <Component: roArray> =
 ```
 
 You also also pass flags for json parsing. `parseJsonFlags` is passed to the [ParseJson()](https://developer.roku.com/en-ca/docs/references/brightscript/language/global-utility-functions.md#parsejsonjsonstring-as-string-flags---as-string-as-object) function.
+
 ```
 Brightscript Debugger> r = Requests().get("https://api.github.com/events", {parseJsonFlags:"i"})
 Brightscript Debugger> ?r.json
 ```
+
 Or disable json parsing
+
 ```
 Brightscript Debugger> r = Requests().get("https://api.github.com/events", {parseJson:false})
 Brightscript Debugger> ?r.json
 ```
+
 ### Custom Headers
 
 If you’d like to add HTTP headers to a request, simply pass in an `AA` to the `headers` key in the args dictionary.
@@ -109,6 +120,7 @@ Brightscript Debugger> r = Requests().get(url, {"headers":headers})
 ### More complicated POST requests
 
 Instead of encoding the `AA` yourself, you can also pass it directly using the `json` parameter
+
 ```
 Brightscript Debugger> url = "https://httpbin.org/post"
 Brightscript Debugger> payload = {"some": "data"}
@@ -116,7 +128,6 @@ Brightscript Debugger> r = Requests().post(url, {"json":payload})
 ```
 
 Using the `json` parameter in the request will change the `Content-Type` in the header to `application/json`.
-
 
 ### Response Status Codes
 
@@ -129,6 +140,7 @@ Brightscript Debugger>  200
 ### Response Headers
 
 We can view the server’s response headers using an AA:
+
 ```
 Brightscript Debugger> ?r.headers
 Brightscript Debugger> <Component: roAssociativeArray> =
@@ -147,6 +159,7 @@ Brightscript Debugger> <Component: roAssociativeArray> =
 ### Timeouts
 
 You can tell Requests to stop waiting for a response after a given number of seconds with the `timeout` parameter (int).
+
 ```
 Brightscript Debugger> r = Requests().get("https://httpbin.org/delay/10", {"timeout":1})
 Brightscript Debugger> <Component: roAssociativeArray> =
@@ -161,11 +174,13 @@ Brightscript Debugger> <Component: roAssociativeArray> =
 ### Caching
 
 You can tell Requests to use cache (on by default) by passing the `useCache` parameter (boolean). This will automatically cache the request if there are `cache-control` headers in the response.
+
 ```
 Brightscript Debugger> r = Requests().get("https://httpbin.org/cache/60", {"useCache":true})
 ```
 
 You can see if the cache was hit by checking the `cacheHit` value on the Response object.
+
 ```
 Brightscript Debugger> r = Requests().get("https://httpbin.org/cache/60", {"useCache":true})
 Brightscript Debugger> ?r.cachehit
@@ -176,6 +191,7 @@ Brightscript Debugger> true
 ```
 
 If the server does not return `cache-control` headers or you want to manually specify the time to cache a request just pass the `cacheSeconds` parameter (int) to Requests.
+
 ```
 Brightscript Debugger> r = Requests().get("https://httpbin.org/get", {"useCache":true, "cacheSeconds":300})
 ```
@@ -183,15 +199,16 @@ Brightscript Debugger> r = Requests().get("https://httpbin.org/get", {"useCache"
 #### Notes about Cache implementation
 
 Roku's Cachefs:
-* The cache implementation uses Roku's `cachefs` (https://sdkdocs.roku.com/display/sdkdoc/File+System)
+
+* The cache implementation uses Roku's `cachefs` (<https://sdkdocs.roku.com/display/sdkdoc/File+System>)
 * `cachefs` is available as a Beta feature starting in Roku OS 8.
 * `cachefs` exists across channel launches but will evict data when more space is required for another Channel.
 
 Cache Keys and Storage Location
+
 * Requests uses an MD5 hash of the URL + Request Headers being passed as the cache key
 * Requests stores the cached request as a file in `cachefs:/{MD5_HASH}`. Please be aware of this if your channel is storing things in the `cachefs:/` space as there is a very minute possiibility of name collisions.
 * The cache data is stored as a file with the first line as a unix epoch of the time the file was written (time the first request was made).  Subsequient requests read the file and compute/compare timestamps to determine if the cached file is still valid or not.
-
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Brightscript Debugger> r = Requests().get("https://httpbin.org/get", {"useCache"
 
 Roku's Cachefs:
 
-* The cache implementation uses Roku's `cachefs` (<https://sdkdocs.roku.com/display/sdkdoc/File+System>)
+* The cache implementation uses Roku's `cachefs` (https://sdkdocs.roku.com/display/sdkdoc/File+System)
 * `cachefs` is available as a Beta feature starting in Roku OS 8.
 * `cachefs` exists across channel launches but will evict data when more space is required for another Channel.
 


### PR DESCRIPTION
## Changes
- Fixes build badge - see [here ](https://github.com/badges/shields/issues/8671) for more information
- Fixes build badge link - now takes you to the `build.yml` workflow results as intended
- Fix markdown formatting (linting errors from vscode extension)